### PR TITLE
テーブルヘッダーに各種リンクを追加

### DIFF
--- a/src/components/SkillTable/SkillTable.tsx
+++ b/src/components/SkillTable/SkillTable.tsx
@@ -12,6 +12,7 @@ type TableData = {
 
 type Props = {
   title: string
+  link?: string
   frontEndProps?: TableData[]
   backEndProps?: TableData[]
 }
@@ -36,7 +37,7 @@ const SkillTable: React.FC<Props> = (props: Props) => {
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(5)
 
-  const { title, frontEndProps, backEndProps } = props
+  const { title, link, frontEndProps, backEndProps } = props
 
   useEffect(() => {
     if (frontEndProps && !frontEndRows.length) {
@@ -71,7 +72,18 @@ const SkillTable: React.FC<Props> = (props: Props) => {
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell align="center" colSpan={12} sx={{ color: 'white', backgroundColor: rgba(63, 81, 181, 1) }}>
+              <TableCell
+                onClick={() => {
+                  window.open(link, '_blank')
+                }}
+                align="center"
+                colSpan={12}
+                sx={{
+                  cursor: 'pointer',
+                  color: 'white',
+                  backgroundColor: rgba(63, 81, 181, 1),
+                }}
+              >
                 {title}
               </TableCell>
             </TableRow>

--- a/src/components/SkillTables/SkillTables.tsx
+++ b/src/components/SkillTables/SkillTables.tsx
@@ -65,8 +65,16 @@ const SkillTables: React.FC = () => {
     <>
       {frontEndProps && backEndProps ? (
         <>
-          <SkillTable title="Front-End Goal Image" frontEndProps={frontEndProps} />
-          <SkillTable title="Back-End Goal Image" backEndProps={backEndProps} />
+          <SkillTable
+            title="Front-End Goal Image"
+            link="https://github.com/Yuisei-Maruyama/MyPortfolio"
+            frontEndProps={frontEndProps}
+          />
+          <SkillTable
+            title="Back-End Goal Image"
+            link="https://github.com/Yuisei-Maruyama/MyPortfolio_Backend"
+            backEndProps={backEndProps}
+          />
         </>
       ) : (
         <></>


### PR DESCRIPTION
下記の画像のヘッダータイトル部分にリンク追加  

![スクリーンショット 2022-01-05 23 58 25](https://user-images.githubusercontent.com/76277215/148238917-5eeb5580-184f-416a-8658-1e5f00c9304a.png)

