### PR TITLE
ドキュメントリストのマークダウン表示ができてない

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { Container } from '@material-ui/core'
+import { Box } from '@mui/material'
+import { rgba } from 'polished'
 import { Main, Board, History, Art, Travel, Document } from '@/pages'
 import { Header2, Footer, MarkdownPreviewer } from '@/components'
 
@@ -21,7 +23,9 @@ const App: React.FC = () => {
               <Route path="/documents/:label" component={MarkdownPreviewer} />
           </Switch>
         </Container>
-        <Footer />
+        <Box sx={{ position: 'fixed', width: '100%', bottom: 0, right: 0, backgroundColor: rgba(0,26,26, 1) }}>
+          <Footer />
+        </Box>
       </Router>
     </div>
   )

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,9 +7,8 @@ const Footer: React.FC = () => {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'flex-end',
-        marginTop: 30,
         height: 40,
-        borderTop: 'solid 1px white',
+        borderTop: 'solid 1px #06D8D7',
       }}
     >
       <p style={{ marginRight: 10 }}>created by Yuisei Maruyama</p>

--- a/src/pages/Document.tsx
+++ b/src/pages/Document.tsx
@@ -11,26 +11,32 @@ const Document: React.FC = () => {
   const { getParams, params } = useSetParams()
 
   return (
-    <Box sx={{ margin: "2% 2%", display: 'flex' }}>
-      <TreeView
-        aria-label="icon expansion"
-        defaultCollapseIcon={<ExpandMoreIcon />}
-        defaultExpandIcon={<ChevronRightIcon />}
-        sx={{ height: 1200, overflowY: 'auto' }}
-      >
-        <DocumentList getParams={getParams} />
-      </TreeView>
-      <div>
+    <Box sx={{ margin: "2% 2% 5% 2%", display: 'flex' }}>
+      <Box sx={{ padding: 3, border: "solid 1px #06D8D7", borderRadius: 3 }}>
+        <TreeView
+          aria-label="icon expansion"
+          defaultCollapseIcon={<ExpandMoreIcon />}
+          defaultExpandIcon={<ChevronRightIcon />}
+          sx={{ overflowY: 'auto' }}
+        >
+          <DocumentList getParams={getParams} />
+        </TreeView>
+      </Box>
+      <>
         {
           params
             ? (
-              <Box sx={{ width: '90%', paddingLeft: '6%' }}>
+              <Box sx={{ width: '75%', paddingLeft: '6%' }}>
                 <MarkdownPreviewer fileName={`${params}.md`} />
               </Box>
             )
-            : <p>左のドキュメントリストを選択すると、ここにMarkdownがプレビューされます。</p>
+            : (
+              <Box sx={{ marginLeft: '20%' }}>
+                <p>左のドキュメントリストを選択すると、ここにMarkdownがプレビューされます。</p>
+              </Box>
+            )
         }
-      </div>
+      </>
     </Box>
   )
 }


### PR DESCRIPTION
#86 

`/documents` において指定したラベルに対する対象のマークダウン要素を表示できるように修正した。