### PR TITLE
ComponentList に Circular の説明がない

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ ex.) Doing -> Closed ラベルに変更
 | --- | --- | --- |
 | react | 17.0.2 | ユーザインタフェース構築のためのJavaScriptライブラリ |
 | typescript | 4.1.2 | JavaScriptに対して、静的型付けとクラスベースオブジェクト指向を加えた言語 |
-| react-router-dom | 5.2.0 | ルーティングを定義するためのライブラリ |
+| [react-router-dom](https://github.com/remix-run/react-router#readme) | 5.2.0 | ルーティングを定義するためのライブラリ |
 | [react-app-rewired](https://www.npmjs.com/package/react-app-rewired) | 2.1.8 | webpack の設定を上書きしてエイリアス設定しているパスの解決を行う |
-| react-beautiful-dnd | 13.1.0 | ドロップ&ドラッグを実現できるライブラリ |
+| [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd) | 13.1.0 | ドロップ&ドラッグを実現できるライブラリ |
 | [react-vertical-timeline-component](https://stephane-monnot.github.io/react-vertical-timeline/#/) | 3.5.2 | タイムライムの表示 |
-| [@uiw/react-md-editor](https://uiwjs.github.io/react-markdown-preview) | ReactでMarkdownを表示できるようにするライブラリ | 3.9.1 |
+| [@uiw/react-md-editor](https://uiwjs.github.io/react-markdown-preview) | 3.9.1 | ReactでMarkdownを表示できるようにするライブラリ |
 | axios | 0.24.0 | PromiseベースのHTTP Clientライブラリ |
 | uuid | 8.3.2 | uuidを付与する |
 | sass | 1.45.1 | Sass をコンパイルするためのモジュール |

--- a/documents/README.md
+++ b/documents/README.md
@@ -69,11 +69,11 @@ ex.) Doing -> Closed ラベルに変更
 | --- | --- | --- |
 | react | 17.0.2 | ユーザインタフェース構築のためのJavaScriptライブラリ |
 | typescript | 4.1.2 | JavaScriptに対して、静的型付けとクラスベースオブジェクト指向を加えた言語 |
-| react-router-dom | 5.2.0 | ルーティングを定義するためのライブラリ |
+| [react-router-dom](https://github.com/remix-run/react-router#readme) | 5.2.0 | ルーティングを定義するためのライブラリ |
 | [react-app-rewired](https://www.npmjs.com/package/react-app-rewired) | 2.1.8 | webpack の設定を上書きしてエイリアス設定しているパスの解決を行う |
-| react-beautiful-dnd | 13.1.0 | ドロップ&ドラッグを実現できるライブラリ |
+| [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd) | 13.1.0 | ドロップ&ドラッグを実現できるライブラリ |
 | [react-vertical-timeline-component](https://stephane-monnot.github.io/react-vertical-timeline/#/) | 3.5.2 | タイムライムの表示 |
-| [@uiw/react-md-editor](https://uiwjs.github.io/react-markdown-preview) | ReactでMarkdownを表示できるようにするライブラリ | 3.9.1 |
+| [@uiw/react-md-editor](https://uiwjs.github.io/react-markdown-preview) | 3.9.1 | ReactでMarkdownを表示できるようにするライブラリ |
 | axios | 0.24.0 | PromiseベースのHTTP Clientライブラリ |
 | uuid | 8.3.2 | uuidを付与する |
 | sass | 1.45.1 | Sass をコンパイルするためのモジュール |
@@ -88,7 +88,6 @@ ex.) Doing -> Closed ラベルに変更
 | lint-staged | 11.1.2 | commitしたファイル(Stagingにあるファイル)にlintを実行する |
 | [react-icons](https://react-icons.github.io/react-icons) | 4.2.0 | `Ant Design` や `Material Design`などを集めたアイコンの宝庫 |
 | [dts-gen](https://github.com/microsoft/dts-gen) | 0.6.0 | ライブラリで型定義ファイルがない場合に `XXX.d.ts` を生成する |
-|  | | |
 |  | | |
 |  | | |
 

--- a/src/components/ComponentList/ComponentList.tsx
+++ b/src/components/ComponentList/ComponentList.tsx
@@ -31,7 +31,8 @@ const ComponentList: React.FC<Props> = (props: Props) => {
         <TreeItem nodeId="4" label="SkillTable" onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => previewComponent(e)} />
         <TreeItem nodeId="5" label="ResumeTable" onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => previewComponent(e)} />
       </TreeItem>
-      <TreeItem nodeId="6" label="Footer" onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => previewComponent(e)} />
+      <TreeItem nodeId="6" label="Circular" onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => previewComponent(e)}></TreeItem>
+      <TreeItem nodeId="100" label="Footer" onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => previewComponent(e)} />
     </>
   )
 }

--- a/src/components/ComponentPreviewTabs/ComponentPreviewTabs.tsx
+++ b/src/components/ComponentPreviewTabs/ComponentPreviewTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { AppBar, Tabs, Tab, Typography, Box, List, ListItem, ListItemText } from '@mui/material'
 import { rgba } from 'polished'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
-import { Header, Footer } from '@/components'
+import { Header, Circular, Footer } from '@/components'
 
 interface TabPanelProps {
   children?: React.ReactNode
@@ -60,8 +60,22 @@ const ComponentPreviewTabs: React.FC<Props> = (props: Props) => {
   const [value, setValue] = useState(0)
 
   const componentList = [
-    { name: 'Header', tag: Header },
-    { name: 'Footer', tag: Footer },
+    {
+      name: 'Header',
+      desc: `Headerを構成するコンポーネント`,
+      tag: Header
+    },
+    {
+      name: 'Circular',
+      desc: `Circularを構成するコンポーネント`,
+      tag: Circular,
+      props: { length: 8, value: 0, items: ['1', '2', '3', '4', '5', '6', '7', '8'] }
+    },
+    {
+      name: 'Footer',
+      desc: `Footerを構成するコンポーネント`,
+      tag: Footer
+    },
   ]
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -88,18 +102,36 @@ const ComponentPreviewTabs: React.FC<Props> = (props: Props) => {
         <List dense={true} sx={{ marginBottom: 3 }}>
             <ListItem>
               <ListItemText>Name:<span style={{ fontWeight: 'bold', marginLeft: 10 }}>{ params }</span></ListItemText>
-          </ListItem>
-          { input
-            ? (
-              <>
-                <ListItem>
-                  <ListItemText>Input:{ input }</ListItemText>
-                </ListItem>
-              </>
-            )
-            :
-            <></>
-          }
+            </ListItem>
+            <ListItem>
+            <Box sx={{ display: 'flex' }}>
+              <ListItemText>Description:</ListItemText>
+              <ListItemText sx={{ marginLeft: 5}}>
+                  {
+                    componentList.filter(component => component.name === params).map((component, index) =>
+                    <Typography component='div' key={index}>
+                        {
+                          component.desc.match(/\n/) ? component.desc.split('\n').map((txt, index) =>
+                            <div key={index}> { txt }</div>
+                          ) : component.desc
+                        }
+                    </Typography>
+                  )}
+              </ListItemText>
+            </Box>
+            </ListItem>
+            {
+              input
+              ? (
+                <>
+                  <ListItem>
+                    <ListItemText>Input:{ input }</ListItemText>
+                  </ListItem>
+                </>
+              )
+              :
+              <></>
+            }
             <ListItem>
               <ListItemText>Demo:</ListItemText>
             </ListItem>
@@ -107,13 +139,29 @@ const ComponentPreviewTabs: React.FC<Props> = (props: Props) => {
         <>
           {
             componentList.filter(component => component.name === params).map((component, index) => {
-                return <component.tag key={index} />
+              return component.props ? <component.tag key={index} {...component.props}  /> : <component.tag key={index} />
             })
           }
         </>
       </TabPanel>
       <TabPanel value={value} index={1}>
-        Props
+        <Typography variant='h6'>＜親コンポーネントから渡される Props 情報＞</Typography>
+        <List dense={true} sx={{ marginBottom: 3 }}>
+          <ListItem>
+              <ListItemText>{componentList.filter(component => component.name === params).map((component, index) => {
+                return component.props
+                  ? Object.entries(component.props).map((prop, index) => {
+                    return (
+                      <Box sx={{ display: 'flex'}} key={index}>
+                        <Typography sx={{ fontSize: 18 }}>{prop[0]}:</Typography>
+                        <Typography sx={{ marginLeft: 8}}>{Array.isArray(prop[1]) ? 'Array' : (typeof prop[1]).charAt(0).toUpperCase() + (typeof prop[1]).slice(1)}</Typography>
+                      </Box>
+                    )
+                    })
+                  : <p key={index}>Props is Nothing.</p>
+              }) }</ListItemText>
+          </ListItem>
+        </List>
       </TabPanel>
       <TabPanel value={value} index={2}>
         Events

--- a/src/components/ComponentPreviewTabs/ComponentPreviewTabs.tsx
+++ b/src/components/ComponentPreviewTabs/ComponentPreviewTabs.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { AppBar, Tabs, Tab, Typography, Box, List, ListItem, ListItemText } from '@mui/material'
+import { AppBar, Tabs, Tab, Typography, Box, List, ListItem, ListItemText, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material'
 import { rgba } from 'polished'
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Header, Circular, Footer } from '@/components'
@@ -145,21 +145,41 @@ const ComponentPreviewTabs: React.FC<Props> = (props: Props) => {
         </>
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <Typography variant='h6'>＜親コンポーネントから渡される Props 情報＞</Typography>
         <List dense={true} sx={{ marginBottom: 3 }}>
           <ListItem>
-              <ListItemText>{componentList.filter(component => component.name === params).map((component, index) => {
-                return component.props
-                  ? Object.entries(component.props).map((prop, index) => {
-                    return (
-                      <Box sx={{ display: 'flex'}} key={index}>
-                        <Typography sx={{ fontSize: 18 }}>{prop[0]}:</Typography>
-                        <Typography sx={{ marginLeft: 8}}>{Array.isArray(prop[1]) ? 'Array' : (typeof prop[1]).charAt(0).toUpperCase() + (typeof prop[1]).slice(1)}</Typography>
-                      </Box>
-                    )
-                    })
-                  : <p key={index}>Props is Nothing.</p>
-              }) }</ListItemText>
+            <TableContainer component={Paper}>
+              <Table sx={{ minWidth: 350 }} aria-label="simple table">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Props Name</TableCell>
+                    <TableCell align="right">Type</TableCell>
+                    <TableCell align="right">Example</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {componentList.filter(component => component.name === params).map((component, index) => {
+                    return component.props
+                      ? Object.entries(component.props).map((prop, index) => {
+                        return (
+                          <TableRow
+                            key={index}
+                            sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                          >
+                            <TableCell component="th" scope="row">{prop[0]}</TableCell>
+                            <TableCell align="right">{Array.isArray(prop[1]) ? 'Array' + `<${ typeof prop[1][0] }>` : (typeof prop[1]).charAt(0).toUpperCase() + (typeof prop[1]).slice(1)}</TableCell>
+                            <TableCell align="right">{prop[1]}</TableCell>
+                          </TableRow>
+                        )
+                        })
+                      : (
+                        <TableRow key={index}>
+                          <TableCell key={index}>No props by the parent component.</TableCell>
+                        </TableRow>
+                      )
+                  })}
+                </TableBody>
+                </Table>
+            </TableContainer>
           </ListItem>
         </List>
       </TabPanel>


### PR DESCRIPTION
## 作業概要

- ComponentList に Circular を追加
- ComponentPreviewTabs の Props タブにpropsの詳細表示テーブルを実装
  

![componentListPreview](https://user-images.githubusercontent.com/76277215/150563511-4065bfcf-ddda-4eaf-a7c7-dce3d018ace2.gif)

