### PR TITLE
ドキュメント内の README.md にルート直下の README.md を上書きすることを自動化できていない

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,29 +29,40 @@ Issueに付与されたラベルごとの管理がしづらいことや対象と
 | コンポーネントのプレビュー機能 |
 | ドキュメントのプレビュー機能 |
 
+<!--rehype:style=color: black;-->
+
 ---
 
 > GitHub Issue のTodoラベル内容閲覧機能
 >> GitHub Issue に付与されたTodoラベルの内容からタイトルと詳細内容が閲覧可能  
 >> Issueタイトルをクリックすることで該当Issueに遷移可能
 
-<img src="public/assets/ReadmeGifs/slider.gif" width="100%">
+<!--rehype:style=color: white;-->
+
+<img src="https://github.com/Yuisei-Maruyama/MyPortfolio/blob/main/public/assets/ReadmeGifs/slider.gif?raw=true" width="100%">  
+
+---
 
 > GitHub Issue の新規作成
+<!--rehype:style=color: white;-->
 
-<img src="public/assets/ReadmeGifs/Add-Issue.gif" width="100%">
+<img src="https://github.com/Yuisei-Maruyama/MyPortfolio/blob/main/public/assets/ReadmeGifs/Add-Issue.gif?raw=true" width="100%">  
+
+---
 
 > 付与されたラベルごとの管理機能
-
 >> ドラッグ＆ドロップにおけるラベルの修正  
+<!--rehype:style=color: white;-->
 
 ex.) Todo -> Doing ラベルに変更  
 
-<img src="public/assets/ReadmeGifs/Update-Issue.gif" width="100%">
+<img src="https://github.com/Yuisei-Maruyama/MyPortfolio/blob/main/public/assets/ReadmeGifs/Update-Issue.gif?raw=true" width="100%">  
 
 ex.) Doing -> Closed ラベルに変更  
 
-<img src="public/assets/ReadmeGifs/Closed-Issue.gif" width="100%">
+<img src="https://github.com/Yuisei-Maruyama/MyPortfolio/blob/main/public/assets/ReadmeGifs/Closed-Issue.gif?raw=true" width="100%">  
+
+---
 
 ### 使用技術・バージョン
 | 技術 | version |説明 |
@@ -81,11 +92,16 @@ ex.) Doing -> Closed ラベルに変更
 | [dts-gen](https://github.com/microsoft/dts-gen) | 0.6.0 | ライブラリで型定義ファイルがない場合に `XXX.d.ts` を生成する |
 |  | | |
 |  | | |
+
+<!--rehype:style=color: black;-->  
+
 ### 動作環境
 
 | デバイスの識別 | OS | 対応ブラウザ |
 | --- | --- |--- |
 | PC | macOS Monterey | Google chrome最新 |
+
+<!--rehype:style=color: black;-->
 
 ## 基本設計
 
@@ -103,5 +119,7 @@ ex.) Doing -> Closed ラベルに変更
 | ドキュメントプレビュー画面 | /documents |
 | 対象のドキュメントのプレビュー | /documents/:label |
 | フッダー | - |
+
+<!--rehype:style=color: black;-->
 
 

--- a/README.md
+++ b/README.md
@@ -121,5 +121,3 @@ ex.) Doing -> Closed ラベルに変更
 | フッダー | - |
 
 <!--rehype:style=color: black;-->
-
-

--- a/documents/Commands.md
+++ b/documents/Commands.md
@@ -16,6 +16,13 @@ Already downloaded: /Library/Caches/Homebrew/tree-1.7.0.el_capitan.bottle.1.tar.
 $ tree --version
 tree v1.7.0 (c) 1996 - 2014 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
+# 指定したディレクトリ以下を表示
+tree ディレクトリ名
+
 # 第2階層まで表示する
 $ tree -L 2
+
+# 指定したディレクトリ以下を、ディレクトリのみ、2階層目まで表示
+tree -d -L 2 ディレクトリ名
+
 ```

--- a/documents/Commands.md
+++ b/documents/Commands.md
@@ -1,0 +1,21 @@
+# 便利コマンド
+
+## ディレクトリのツリー構造を表現する
+
+```ts
+# treeコマンドの導入
+# brewでインストール
+
+$ brew install tree
+==> Downloading https://homebrew.bintray.com/bottles/tree-1.7.0.el_capitan.bottl
+Already downloaded: /Library/Caches/Homebrew/tree-1.7.0.el_capitan.bottle.1.tar.gz
+==> Pouring tree-1.7.0.el_capitan.bottle.1.tar.gz
+🍺  /usr/local/Cellar/tree/1.7.0: 7 files, 112.4K
+
+# 以下が動けばインストール成功
+$ tree --version
+tree v1.7.0 (c) 1996 - 2014 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
+
+# 第2階層まで表示する
+$ tree -L 2
+```

--- a/documents/NodeJs.md
+++ b/documents/NodeJs.md
@@ -1,0 +1,38 @@
+# node.js
+
+## fsモジュールの`readFileSync`を使用したファイル読み込みについて
+
+下記のような状態であった場合に root 直下の `README.md` を読み込みたいとする。
+
+```ts
+├── tools
+│   ├── duplicateReadme.ts <- このファイルでREADME.md を読み込みたい
+│   ├── loadPackage.ts
+│   ├── package.json
+│   └── tsconfig.json
+├── README.md
+```
+
+そのような場合、作業ディレクトリからのパスではなく、**fsはパスを作業ディレクトリ**  から辿る！！！  
+上記の作業ディレクトリとは、 **nodeを実行したファイルがあるディレクトリ** のことを指す。
+
+例えば、`MyPortfolio`  の階層で node を実行しようとする。
+
+```ts
+── MyPortfolio  <- ここで node を実行している
+    ├── README.md
+    ├── src
+    ├── tools
+    │   ├── duplicateReadme.ts
+    │   ├── loadPackage.ts
+    │   ├── package.json
+    │   └── tsconfig.json
+```
+
+`readFileSync` のパスは下記のようになる。
+
+(duplicateReadme.ts)
+```ts
+const readme = readFileSync('README.md', 'utf8')  // 正しく読み込める
+const readme = readFileSync('。。・README.md', 'utf8')  // no such file or directory, open になる
+```

--- a/documents/NodeJs.md
+++ b/documents/NodeJs.md
@@ -1,6 +1,82 @@
 # node.js
 
-## fsモジュールの`readFileSync`を使用したファイル読み込みについて
+## path｜パス操作
+
+### パス情報の取得
+
+```ts
+.
+├── documentsA
+│   ├── documentsB
+│   │   └── text.txt
+│   └── test.txt
+├── documentsC
+│   └── test.txt
+└── path.js
+```
+
+下記のような形でパスが指すファイルの ディレクトリ 拡張子 などの情報を取得する。  
+
+```ts
+import path from 'path'
+
+console.log('---- basename ----');
+console.log(path.basename('./documentsA/test.txt'));
+
+console.log('---- dirname ----');
+console.log(path.dirname('./documentsA/test.txt'));
+
+console.log('---- extname ----');
+console.log(path.extname('./documentsA/test.txt'));
+
+console.log('---- parse ----');
+console.log(path.parse('./documentsA/test.txt'));
+```
+
+(実行結果)
+```ts
+---- basename ----
+test.txt
+---- dirname ----
+./documentsA
+---- extname ----
+.txt
+---- parse ----
+{ 
+    root: '',
+    dir: './documentsA',
+    base: 'test.txt',
+    ext: '.txt',
+    name: 'test' 
+}
+```
+
+---
+
+### パスの結合
+
+```ts
+import path from 'path'
+
+console.log(path.relative('./documentsA', './documentsA/documentsB'));
+console.log(path.relative('./documentsA/documentsB', './documentsC'));
+console.log(path.relative('./documentsA', './documentsC'));
+console.log(path.relative('./documentsA', '.'));
+```
+
+(実行結果)
+```ts
+documentsB
+../../documentsC
+../documentsC
+..
+```
+
+## fs｜ファイル操作
+
+### ファイル読み込み
+
+ファイル読み込みには、 fsモジュールの`readFileSync`を使用する。  
 
 下記のような状態であった場合に root 直下の `README.md` を読み込みたいとする。
 
@@ -33,6 +109,57 @@
 
 (duplicateReadme.ts)
 ```ts
-const readme = readFileSync('README.md', 'utf8')  // 正しく読み込める
-const readme = readFileSync('。。・README.md', 'utf8')  // no such file or directory, open になる
+readFileSync('README.md', 'utf8')  // 正しく読み込める
+readFileSync('。。・README.md', 'utf8')  // no such file or directory, open になる
+```
+
+---
+
+### ファイルの存在確認
+
+```ts
+documents/
+├── README.md
+・・・
+```
+
+ファイルの存在確認には、fsモジュールの `statSync` を使用する。  
+
+```ts
+const stat = statSync('documents/README.md')
+// 指定ファイルがディレクトリとして存在するか判定する
+console.log(stat.isDirectory()) // true or false
+// 指定ファイルがファイルとして存在するか判定する
+console.log(stat.isFile()) // true or false
+```
+
+### ファイルの書き込み(新規作成 or 上書き)
+
+ファイルの書き込み(新規作成 or 上書き)には、 `writeFileSync` を使用する。  
+
+ファイルが存在しなければ **新規作成** して、存在する場合は **上書き** する。
+
+```ts
+const readme = readFileSync('README.md', 'utf8')
+writeFileSync('documents/README.md', readme, 'utf8')
+```
+
+---
+
+### ファイルの追記
+
+ファイルの追記には、fsモジュールの `appendFileSync` を使用する。  
+
+```ts
+fs.appendFileSync('documents/README.md', '追記文', 'utf8')
+```
+
+---
+
+### ファイル削除
+
+ファイル削除には、 fsモジュールの `unlinkSync` を使用する。
+
+```ts
+fs.unlinkSync('documents/README.md')
 ```

--- a/documents/README.md
+++ b/documents/README.md
@@ -121,5 +121,3 @@ ex.) Doing -> Closed ラベルに変更
 | フッダー | - |
 
 <!--rehype:style=color: black;-->
-
-

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired build && node build-lib",
-    "lint-fix": "eslint --fix './src/**/*.{js,ts,tsx}' && prettier --write './src/**/*.{js,ts,tsx}'",
+    "lint-fix": "eslint --fix './src/**/*.{js,ts,tsx}' && prettier --write './src/**/*.{js,ts,tsx}' && ts-node tools/duplicateReadme.ts",
     "test": "react-app-rewired test",
     "prepare": "husky install"
   },

--- a/src/components/DocumentList/DocumentList.tsx
+++ b/src/components/DocumentList/DocumentList.tsx
@@ -135,7 +135,11 @@ const DocumentList: React.FC<Props> = (props: Props) => {
       </Box>
       <Box sx={{ marginTop: '10%' }}>
         <TreeItem nodeId="25" label="Back-End">
-          <TreeItem nodeId="26" label="Node.js" />
+          <TreeItem
+            nodeId="26"
+            label="NodeJs"
+            onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => previewDocument(e)}
+          />
           <TreeItem nodeId="27" label="OpenAPI" />
         </TreeItem>
       </Box>
@@ -144,6 +148,15 @@ const DocumentList: React.FC<Props> = (props: Props) => {
           <TreeItem
             nodeId="29"
             label="types-cheat-sheet"
+            onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => previewDocument(e)}
+          />
+        </TreeItem>
+      </Box>
+      <Box sx={{ marginTop: '10%' }}>
+        <TreeItem nodeId="101" label="Utils">
+          <TreeItem
+            nodeId="102"
+            label="Commands"
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => previewDocument(e)}
           />
         </TreeItem>

--- a/tools/duplicateReadme.ts
+++ b/tools/duplicateReadme.ts
@@ -1,5 +1,14 @@
-import { readFileSync } from 'fs'
+import { readFileSync, statSync, writeFileSync } from 'fs'
 
 const readme = readFileSync('README.md', 'utf8')
 
-console.log(readme)
+try {
+  const existReadme = statSync('documents/README.md')
+  if (existReadme.isFile()) {
+    writeFileSync('documents/README.md', readme, 'utf8')
+  }
+} catch (err) {
+  console.log(err)
+}
+
+

--- a/tools/duplicateReadme.ts
+++ b/tools/duplicateReadme.ts
@@ -1,0 +1,5 @@
+import { readFileSync } from 'fs'
+
+const readme = readFileSync('README.md', 'utf8')
+
+console.log(readme)

--- a/tools/loadPackage.ts
+++ b/tools/loadPackage.ts
@@ -1,0 +1,12 @@
+// import { readFileSync } from 'fs'
+import packageJson from '../package.json'
+
+// const dependencies = packageJson.dependencies
+const devDependencies = packageJson.devDependencies
+
+// console.log('dependencies', dependencies)
+// console.log('devDependencies', devDependencies['@material-ui/core'])
+
+for (const [key, value] of Object.entries(devDependencies)) {
+  console.log(`${key}: ${value}`)
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,1 @@
+{ "type": "modules" }

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,70 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es2020",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## 作業概要

- ドキュメント配下の README.md にルート直下の README.md を自動的に上書きする

### なぜこの作業を行うのか？

React.js において ルート直下の `README.md` を読み込む機構を作る手段が分からなかったので、  
`documents/README.md` にルート直下の `README.md` と同じ内容のファイルを置いて対応していた。  

- ルート直下の README.md
- ドキュメント配下の README.md

しかし、この状況では片方だけに修正を行って、もう片方を修正し忘れるということが何回もあった。  

そこで、node.js の標準機能を使用して、ファイルを読み込み、対象のファイルに上書きすることを検討した。  

また husky に設定された lint-staged に組み込むことで複製の自動化を実現した。

