### PR TITLE
プロフィールカードのレンダリング領域を全体から個別にする

### DIFF
--- a/src/components/FlippedCard/FlippedCard.tsx
+++ b/src/components/FlippedCard/FlippedCard.tsx
@@ -1,11 +1,10 @@
 import React, { memo } from 'react'
 import styled from 'styled-components'
+import { useFlipped } from '@/customHooks'
 
 type Props = {
   children?: React.ReactNodeArray
   flipDirection?: 'horizontal' | 'vertical'
-  isFlipped: boolean
-  setFlipped: (isFlipped: boolean) => void
 }
 
 const _FlippedCard = styled.div`
@@ -22,10 +21,12 @@ const _scaleX = styled.div`
 `
 
 const FlippedCard: React.FC<Props> = (props: Props) => {
-  const { children, isFlipped, setFlipped } = props
+  const { children } = props
+
+  const { isFlipped, handleSetFlipped } = useFlipped()
 
   const handleHover = () => {
-    setFlipped(!isFlipped)
+    handleSetFlipped(!isFlipped)
   }
 
   return (

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -13,7 +13,6 @@ import { Box } from '@material-ui/core'
 import { Grid } from '@mui/material'
 import { Issues } from '@/types'
 import axios from 'axios'
-import { useFlipped } from '@/customHooks'
 import { skillTableData } from '@/data/skillTableData'
 import { message } from '@/data/message'
 
@@ -42,7 +41,7 @@ const contextValue = {
 const Main = () => {
   const [todoItems, setTodo] = useState<Issues>([])
   const [languages, setLanguages] = useState<Record<string, number>>({})
-  const { isFlipped, handleSetFlipped } = useFlipped()
+  // const { isFlipped, handleSetFlipped } = useFlipped()
   const { frontEndProps, backEndProps } = skillTableData()
 
   const fetchTodo = async () => {
@@ -74,7 +73,7 @@ const Main = () => {
       <Grid container gap={12} sx={{ mt: 6 }}>
         <Grid item lg={1} xl={1} />
         <Grid item sm={6} xs={5} md={4} lg={3} xl={2}>
-          <FlippedCard isFlipped={isFlipped} setFlipped={handleSetFlipped}>
+          <FlippedCard>
             <ProfileFrontCard
               width="100%"
               height="450px"

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -41,7 +41,6 @@ const contextValue = {
 const Main = () => {
   const [todoItems, setTodo] = useState<Issues>([])
   const [languages, setLanguages] = useState<Record<string, number>>({})
-  // const { isFlipped, handleSetFlipped } = useFlipped()
   const { frontEndProps, backEndProps } = skillTableData()
 
   const fetchTodo = async () => {


### PR DESCRIPTION
## 作業概要

プロフィールカードだけがレンダリングされる状態に修正する

- 変更前

![xxx](https://user-images.githubusercontent.com/76277215/173031790-a3e050ff-0015-4e12-8187-cd2f1dc47728.gif)


- 変更後

![xxx](https://user-images.githubusercontent.com/76277215/173031887-57a88a38-d2d1-49aa-a51c-f50923cc1ac2.gif)

