### PR TITLE
隠しコマンドによるアニメーションを追加する

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
   ],
   rules: {
     'no-use-before-define': 'off', // import React from 'react' のエラー回避
-    '@typescript-eslint/no-use-before-define': ['error'],
+    '@typescript-eslint/no-use-before-define': ['error', { "variables": false }], // styled-componentsの定義場所を.tsx下部に設定するため
     'camelCase': 'off',
     'space-before-function-paren': 'off',
     'react/react-in-jsx-scope': 'off',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const App: React.FC = () => {
       <Router>
         <ThemeProvider mode="dark">
           <CommandListProvider commandList={commandList} setComponent={setComponent}>
-              {!isDelete && component}
+            {!isDelete && component}
             <Header></Header>
             <Container maxWidth="xl" style={{ padding: '0 0 70px 0' }}>
               <Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,15 @@ import { Container } from '@material-ui/core'
 import { Box } from '@mui/material'
 import { rgba } from 'polished'
 import { Main, Board, History, Matrix, Travel, Instructions, DocumentsPreviewer, ComponentsPreviewer } from '@/pages'
-import { ThemeProvider, Header, Footer, MarkdownPreviewer, ComponentPreviewTabs } from '@/components'
+import {
+  ThemeProvider,
+  Header,
+  Footer,
+  MarkdownPreviewer,
+  ComponentPreviewTabs,
+  CommandListProvider,
+} from '@/components'
+import { commandList } from './data/commandList'
 
 const App: React.FC = () => {
   return (
@@ -14,24 +22,26 @@ const App: React.FC = () => {
     >
       <Router>
         <ThemeProvider mode="dark">
-          <Header></Header>
-          <Container maxWidth="xl" style={{ padding: '0 0 70px 0' }}>
-            <Switch>
-              <Route exact path="/" component={Main} />
-              <Route exact path="/board" component={Board} />
-              <Route exact path="/history" component={History} />
-              <Route exact path="/matrix" component={Matrix} />
-              <Route exact path="/travel" component={Travel} />
-              <Route exact path="/instructions" component={Instructions} />
-              <Route path="/documents" component={DocumentsPreviewer} />
-              <Route path="/documents/:label" component={MarkdownPreviewer} />
-              <Route path="/components" component={ComponentsPreviewer} />
-              <Route path="/components/:label" component={ComponentPreviewTabs} />
-            </Switch>
-          </Container>
-          <Box sx={{ position: 'fixed', width: '100%', bottom: 0, right: 0, backgroundColor: rgba(0, 26, 26, 1) }}>
-            <Footer />
-          </Box>
+          <CommandListProvider commandList={commandList}>
+            <Header></Header>
+            <Container maxWidth="xl" style={{ padding: '0 0 70px 0' }}>
+              <Switch>
+                <Route exact path="/" component={Main} />
+                <Route exact path="/board" component={Board} />
+                <Route exact path="/history" component={History} />
+                <Route exact path="/matrix" component={Matrix} />
+                <Route exact path="/travel" component={Travel} />
+                <Route exact path="/instructions" component={Instructions} />
+                <Route path="/documents" component={DocumentsPreviewer} />
+                <Route path="/documents/:label" component={MarkdownPreviewer} />
+                <Route path="/components" component={ComponentsPreviewer} />
+                <Route path="/components/:label" component={ComponentPreviewTabs} />
+              </Switch>
+            </Container>
+            <Box sx={{ position: 'fixed', width: '100%', bottom: 0, right: 0, backgroundColor: rgba(0, 26, 26, 1) }}>
+              <Footer />
+            </Box>
+          </CommandListProvider>
         </ThemeProvider>
       </Router>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,10 +19,10 @@ const App: React.FC = () => {
   const [component, setComponent] = useState<ReactNode>()
   const [isDelete, setDeleteComponents] = useState<boolean>(true)
 
-  useInterval(() => {
-    setDeleteComponents(true)
-    setComponent(undefined)
-  }, 37000)
+  useInterval(async() => {
+    await setDeleteComponents(true)
+    await setComponent(undefined)
+  }, 60000)
 
   useEffect(() => {
     setDeleteComponents(false)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,8 @@ const App: React.FC = () => {
 
   useInterval(() => {
     setDeleteComponents(true)
-  }, 40000)
+    setComponent(undefined)
+  }, 37000)
 
   useEffect(() => {
     setDeleteComponents(false)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useState, ReactNode } from 'react'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { Container } from '@material-ui/core'
 import { Box } from '@mui/material'
@@ -15,6 +15,7 @@ import {
 import { commandList } from './data/commandList'
 
 const App: React.FC = () => {
+  const [component, setComponent] = useState<ReactNode>()
   return (
     <div
       className="App"
@@ -22,7 +23,8 @@ const App: React.FC = () => {
     >
       <Router>
         <ThemeProvider mode="dark">
-          <CommandListProvider commandList={commandList}>
+          <CommandListProvider commandList={commandList} setComponent={setComponent}>
+            {component}
             <Header></Header>
             <Container maxWidth="xl" style={{ padding: '0 0 70px 0' }}>
               <Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import React, { useState, ReactNode } from 'react'
+import React, { useState, ReactNode, useEffect } from 'react'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { Container } from '@material-ui/core'
 import { Box } from '@mui/material'
 import { rgba } from 'polished'
-import { Main, Board, History, Matrix, Travel, Instructions, DocumentsPreviewer, ComponentsPreviewer } from '@/pages'
+import { Main, Board, History, Travel, Instructions, DocumentsPreviewer, ComponentsPreviewer } from '@/pages'
 import {
   ThemeProvider,
   Header,
@@ -13,9 +13,20 @@ import {
   CommandListProvider,
 } from '@/components'
 import { commandList } from './data/commandList'
+import useInterval from '@use-it/interval'
 
 const App: React.FC = () => {
   const [component, setComponent] = useState<ReactNode>()
+  const [isDelete, setDeleteComponents] = useState<boolean>(true)
+
+  useInterval(() => {
+    setDeleteComponents(true)
+  }, 40000)
+
+  useEffect(() => {
+    setDeleteComponents(false)
+  }, [component])
+
   return (
     <div
       className="App"
@@ -24,14 +35,14 @@ const App: React.FC = () => {
       <Router>
         <ThemeProvider mode="dark">
           <CommandListProvider commandList={commandList} setComponent={setComponent}>
-            {component}
+              {!isDelete && component}
             <Header></Header>
             <Container maxWidth="xl" style={{ padding: '0 0 70px 0' }}>
               <Switch>
                 <Route exact path="/" component={Main} />
                 <Route exact path="/board" component={Board} />
                 <Route exact path="/history" component={History} />
-                <Route exact path="/matrix" component={Matrix} />
+                {/* <Route exact path="/matrix" component={Matrix} /> */}
                 <Route exact path="/travel" component={Travel} />
                 <Route exact path="/instructions" component={Instructions} />
                 <Route path="/documents" component={DocumentsPreviewer} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {useState, ReactNode } from 'react'
+import React, { useState, ReactNode } from 'react'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { Container } from '@material-ui/core'
 import { Box } from '@mui/material'

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+
+const Alert: React.FC = () => {
+  alert('アラートが表示されるかのテスト')
+  return null
+}
+
+export default Alert

--- a/src/components/CommandList/CommandList.tsx
+++ b/src/components/CommandList/CommandList.tsx
@@ -1,0 +1,90 @@
+import React, { useContext } from 'react'
+import { TextField, InputAdornment, Typography } from '@mui/material'
+import styled from 'styled-components'
+import { CommandListContext } from '@/components/CommandListArea/CommandListArea'
+
+const _ActiveCommandWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 800px;
+  height: 500px;
+  color: #06d8d7;
+  background-color: rgba(0, 0, 0, 0.7);
+  border: 1px solid #06d8d7;
+  z-index: 1000;
+`
+
+const $CommandTextField = styled(TextField)`
+  width: 96%;
+  display: block;
+  margin: 0 auto;
+  background-color: rgba(0, 0, 0, 0.9);
+  box-shadow: -1px -1px #06d8d7, 1px -1px #06d8d7, 1px 1px #06d8d7, -1px 1px #06d8d7, 0 0 0.1em #06d8d7,
+    0 0 0.1em #06d8d7 inset, 0 0 1em #06d8d7, 0 0 1em #06d8d7 inset;
+  & .MuiOutlinedInput-root {
+    width: 100%;
+  }
+  & input {
+    color: #06d8d7;
+    width: 100%;
+    margin-left: 10px;
+    font-size: 20px;
+  }
+`
+
+const $InputAdornment = styled(InputAdornment)`
+  & > p {
+    margin-left: 15px;
+    color: #06d8d7;
+    font-size: 18px;
+  }
+`
+
+const _CommandOptions = styled.div`
+  margin-top: 30px;
+`
+const _CommandOption = styled.div`
+  padding: 10px 25px;
+  width: 100%;
+  height: 80px;
+  border-top: 1px solid #06d8d7;
+  border-bottom: 1px solid #06d8d7;
+  cursor: pointer;
+  :hover {
+    box-shadow: -1px -1px #06d8d7, 1px -1px #06d8d7, 1px 1px #06d8d7, -1px 1px #06d8d7, 0 0 0.1em #06d8d7,
+      0 0 0.1em #06d8d7 inset, 0 0 0.5em #06d8d7, 0 0 0.5em #06d8d7 inset, 0 0 1em #06d8d7, 0 0 1em #06d8d7 inset;
+  }
+`
+
+const $CommandTitle = styled(Typography)`
+  font-weight: bold;
+`
+
+const CommandList: React.FC = () => {
+  const commandList = useContext(CommandListContext)
+
+  console.log(commandList)
+
+  return (
+    <_ActiveCommandWrapper>
+      <$CommandTextField
+        variant="outlined"
+        InputProps={{
+          startAdornment: <$InputAdornment position="start">&gt;</$InputAdornment>,
+        }}
+      />
+      <_CommandOptions>
+        {commandList.map((command, index) => (
+          <_CommandOption key={index}>
+            <$CommandTitle variant="h6">{command.title}</$CommandTitle>
+            <Typography>{command.desc}</Typography>
+          </_CommandOption>
+        ))}
+      </_CommandOptions>
+    </_ActiveCommandWrapper>
+  )
+}
+
+export default CommandList

--- a/src/components/CommandList/CommandList.tsx
+++ b/src/components/CommandList/CommandList.tsx
@@ -22,7 +22,11 @@ const CommandList: React.FC<Props> = ({ setIsRunning, setComponent }) => {
   }
 
   return (
-    <_ActiveCommandWrapper>
+    <_ActiveCommandWrapper
+      onClick={(event) => {
+        event.stopPropagation()
+      }}
+    >
       <$CommandTextField
         variant="outlined"
         InputProps={{
@@ -32,7 +36,28 @@ const CommandList: React.FC<Props> = ({ setIsRunning, setComponent }) => {
         onChange={(e) => handleChangeText(e.target.value)}
       />
       <_CommandOptions>
-        {seachCommand && seachCommand === 'all'
+        {!seachCommand ? (
+          <_CommandOptionBase>
+            <$CommandTitle variant="h6">Please input any command 👨‍💻</$CommandTitle>
+          </_CommandOptionBase>
+        ) : seachCommand === 'all' ? (
+          commandList.map((command, index) => (
+            <$CommandOption key={index} onClick={() => handleClickCommand(command.component)}>
+              <$CommandTitle variant="h6">{command.title}</$CommandTitle>
+              <Typography>{command.desc}</Typography>
+            </$CommandOption>
+          ))
+        ) : (
+          commandList
+            .filter((command) => command.name.startsWith(seachCommand))
+            .map((command, index) => (
+              <$CommandOption key={index} onClick={() => handleClickCommand(command.component)}>
+                <$CommandTitle variant="h6">{command.title}</$CommandTitle>
+                <Typography>{command.desc}</Typography>
+              </$CommandOption>
+            ))
+        )}
+        {/* {seachCommand === 'all'
           ? commandList.map((command, index) => (
               <_CommandOption key={index} onClick={() => handleClickCommand(command.component)}>
                 <$CommandTitle variant="h6">{command.title}</$CommandTitle>
@@ -46,7 +71,7 @@ const CommandList: React.FC<Props> = ({ setIsRunning, setComponent }) => {
                   <$CommandTitle variant="h6">{command.title}</$CommandTitle>
                   <Typography>{command.desc}</Typography>
                 </_CommandOption>
-              ))}
+              ))} */}
       </_CommandOptions>
     </_ActiveCommandWrapper>
   )
@@ -60,7 +85,7 @@ const _ActiveCommandWrapper = styled.div`
   width: 800px;
   /* height: 500px; */
   color: #06d8d7;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.6);
   border: 1px solid #06d8d7;
   z-index: 1000;
 `
@@ -69,7 +94,7 @@ const $CommandTextField = styled(TextField)`
   width: 96%;
   display: block;
   margin: 20px auto 0;
-  background-color: rgba(0, 0, 0, 0.9);
+  background-color: rgba(0, 0, 0, 0.6);
   box-shadow: -1px -1px #06d8d7, 1px -1px #06d8d7, 1px 1px #06d8d7, -1px 1px #06d8d7, 0 0 0.1em #06d8d7,
     0 0 0.1em #06d8d7 inset, 0 0 1em #06d8d7, 0 0 1em #06d8d7 inset;
   & .MuiOutlinedInput-root {
@@ -94,12 +119,16 @@ const $InputAdornment = styled(InputAdornment)`
 const _CommandOptions = styled.div`
   margin-top: 30px;
 `
-const _CommandOption = styled.div`
+
+const _CommandOptionBase = styled.div`
   padding: 25px;
   width: 100%;
   height: 100px;
   border-top: 1px solid #06d8d7;
   border-bottom: 1px solid #06d8d7;
+`
+
+const $CommandOption = styled(_CommandOptionBase)`
   cursor: pointer;
   :hover {
     box-shadow: -1px -1px #06d8d7, 1px -1px #06d8d7, 1px 1px #06d8d7, -1px 1px #06d8d7, 0 0 0.1em #06d8d7,

--- a/src/components/CommandList/CommandList.tsx
+++ b/src/components/CommandList/CommandList.tsx
@@ -32,7 +32,7 @@ const CommandList: React.FC<Props> = ({ setIsRunning, setComponent }) => {
         onChange={(e) => handleChangeText(e.target.value)}
       />
       <_CommandOptions>
-        {!seachCommand
+        {seachCommand && seachCommand === 'all'
           ? commandList.map((command, index) => (
               <_CommandOption key={index} onClick={() => handleClickCommand(command.component)}>
                 <$CommandTitle variant="h6">{command.title}</$CommandTitle>
@@ -58,7 +58,7 @@ const _ActiveCommandWrapper = styled.div`
   left: 50%;
   transform: translateX(-50%);
   width: 800px;
-  height: 500px;
+  /* height: 500px; */
   color: #06d8d7;
   background-color: rgba(0, 0, 0, 0.7);
   border: 1px solid #06d8d7;
@@ -68,7 +68,7 @@ const _ActiveCommandWrapper = styled.div`
 const $CommandTextField = styled(TextField)`
   width: 96%;
   display: block;
-  margin: 0 auto;
+  margin: 20px auto 0;
   background-color: rgba(0, 0, 0, 0.9);
   box-shadow: -1px -1px #06d8d7, 1px -1px #06d8d7, 1px 1px #06d8d7, -1px 1px #06d8d7, 0 0 0.1em #06d8d7,
     0 0 0.1em #06d8d7 inset, 0 0 1em #06d8d7, 0 0 1em #06d8d7 inset;

--- a/src/components/CommandList/CommandList.tsx
+++ b/src/components/CommandList/CommandList.tsx
@@ -1,13 +1,14 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, ReactNode } from 'react'
 import { TextField, InputAdornment, Typography } from '@mui/material'
 import styled from 'styled-components'
 import { CommandListContext } from '@/components/CommandListArea/CommandListArea'
 
 type Props = {
   setIsRunning: (value: React.SetStateAction<boolean>) => void
+  setComponent: React.Dispatch<React.SetStateAction<React.ReactNode>>
 }
 
-const CommandList: React.FC<Props> = ({ setIsRunning }) => {
+const CommandList: React.FC<Props> = ({ setIsRunning, setComponent }) => {
   const commandList = useContext(CommandListContext)
   const [seachCommand, setSearchCommand] = useState<string>('')
 
@@ -15,8 +16,9 @@ const CommandList: React.FC<Props> = ({ setIsRunning }) => {
     setSearchCommand(value)
   }
 
-  const handleClickCommand = () => {
+  const handleClickCommand = (component: ReactNode) => {
     setIsRunning(false)
+    setComponent(component)
   }
 
   return (
@@ -32,7 +34,7 @@ const CommandList: React.FC<Props> = ({ setIsRunning }) => {
       <_CommandOptions>
         {!seachCommand
           ? commandList.map((command, index) => (
-              <_CommandOption key={index} onClick={handleClickCommand}>
+              <_CommandOption key={index} onClick={() =>handleClickCommand(command.component)}>
                 <$CommandTitle variant="h6">{command.title}</$CommandTitle>
                 <Typography>{command.desc}</Typography>
               </_CommandOption>
@@ -40,7 +42,7 @@ const CommandList: React.FC<Props> = ({ setIsRunning }) => {
           : commandList
               .filter((command) => command.name.includes(seachCommand))
               .map((command, index) => (
-                <_CommandOption key={index}>
+                <_CommandOption key={index} onClick={() => handleClickCommand(command.component)}>
                   <$CommandTitle variant="h6">{command.title}</$CommandTitle>
                   <Typography>{command.desc}</Typography>
                 </_CommandOption>

--- a/src/components/CommandList/CommandList.tsx
+++ b/src/components/CommandList/CommandList.tsx
@@ -34,7 +34,7 @@ const CommandList: React.FC<Props> = ({ setIsRunning, setComponent }) => {
       <_CommandOptions>
         {!seachCommand
           ? commandList.map((command, index) => (
-              <_CommandOption key={index} onClick={() =>handleClickCommand(command.component)}>
+              <_CommandOption key={index} onClick={() => handleClickCommand(command.component)}>
                 <$CommandTitle variant="h6">{command.title}</$CommandTitle>
                 <Typography>{command.desc}</Typography>
               </_CommandOption>
@@ -95,9 +95,9 @@ const _CommandOptions = styled.div`
   margin-top: 30px;
 `
 const _CommandOption = styled.div`
-  padding: 10px 25px;
+  padding: 25px;
   width: 100%;
-  height: 80px;
+  height: 100px;
   border-top: 1px solid #06d8d7;
   border-bottom: 1px solid #06d8d7;
   cursor: pointer;

--- a/src/components/CommandList/CommandList.tsx
+++ b/src/components/CommandList/CommandList.tsx
@@ -1,7 +1,54 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { TextField, InputAdornment, Typography } from '@mui/material'
 import styled from 'styled-components'
 import { CommandListContext } from '@/components/CommandListArea/CommandListArea'
+
+type Props = {
+  setIsRunning: (value: React.SetStateAction<boolean>) => void
+}
+
+const CommandList: React.FC<Props> = ({ setIsRunning }) => {
+  const commandList = useContext(CommandListContext)
+  const [seachCommand, setSearchCommand] = useState<string>('')
+
+  const handleChangeText = (value: string) => {
+    setSearchCommand(value)
+  }
+
+  const handleClickCommand = () => {
+    setIsRunning(false)
+  }
+
+  return (
+    <_ActiveCommandWrapper>
+      <$CommandTextField
+        variant="outlined"
+        InputProps={{
+          startAdornment: <$InputAdornment position="start">&gt;</$InputAdornment>,
+        }}
+        value={seachCommand}
+        onChange={(e) => handleChangeText(e.target.value)}
+      />
+      <_CommandOptions>
+        {!seachCommand
+          ? commandList.map((command, index) => (
+              <_CommandOption key={index} onClick={handleClickCommand}>
+                <$CommandTitle variant="h6">{command.title}</$CommandTitle>
+                <Typography>{command.desc}</Typography>
+              </_CommandOption>
+            ))
+          : commandList
+              .filter((command) => command.name.includes(seachCommand))
+              .map((command, index) => (
+                <_CommandOption key={index}>
+                  <$CommandTitle variant="h6">{command.title}</$CommandTitle>
+                  <Typography>{command.desc}</Typography>
+                </_CommandOption>
+              ))}
+      </_CommandOptions>
+    </_ActiveCommandWrapper>
+  )
+}
 
 const _ActiveCommandWrapper = styled.div`
   position: fixed;
@@ -61,30 +108,5 @@ const _CommandOption = styled.div`
 const $CommandTitle = styled(Typography)`
   font-weight: bold;
 `
-
-const CommandList: React.FC = () => {
-  const commandList = useContext(CommandListContext)
-
-  console.log(commandList)
-
-  return (
-    <_ActiveCommandWrapper>
-      <$CommandTextField
-        variant="outlined"
-        InputProps={{
-          startAdornment: <$InputAdornment position="start">&gt;</$InputAdornment>,
-        }}
-      />
-      <_CommandOptions>
-        {commandList.map((command, index) => (
-          <_CommandOption key={index}>
-            <$CommandTitle variant="h6">{command.title}</$CommandTitle>
-            <Typography>{command.desc}</Typography>
-          </_CommandOption>
-        ))}
-      </_CommandOptions>
-    </_ActiveCommandWrapper>
-  )
-}
 
 export default CommandList

--- a/src/components/CommandListArea/CommandListArea.tsx
+++ b/src/components/CommandListArea/CommandListArea.tsx
@@ -17,6 +17,12 @@ const CommandListArea: React.FC<Props> = ({ commandList, children, setComponent 
   const handleKeyDown: OnKeyFun = (_, e) => {
     e.preventDefault()
     setIsRunning(true)
+    document.addEventListener('click', handleClose)
+  }
+
+  const handleClose = () => {
+    setIsRunning(false)
+    document.removeEventListener('click',handleClose)
   }
 
   return (

--- a/src/components/CommandListArea/CommandListArea.tsx
+++ b/src/components/CommandListArea/CommandListArea.tsx
@@ -1,0 +1,31 @@
+import React, { useState, createContext } from 'react'
+import Hotkeys, { OnKeyFun } from 'react-hot-keys'
+import { Command } from '@/types'
+import { CommandList } from '@/components'
+
+type Props = {
+  commandList: Command[]
+  children: React.ReactNode[]
+}
+
+export const CommandListContext = createContext<Command[]>([])
+
+const CommandListArea: React.FC<Props> = ({ commandList, children }) => {
+  const [isRunning, setIsRunning] = useState(false)
+
+  const handleKeyDown: OnKeyFun = (_, e) => {
+    e.preventDefault()
+    setIsRunning(true)
+  }
+
+  return (
+    <CommandListContext.Provider value={commandList}>
+      <Hotkeys keyName="command+shift+p" onKeyDown={(_, evn: KeyboardEvent, $) => handleKeyDown(_, evn, $)}>
+        {isRunning ? <CommandList /> : <></>}
+      </Hotkeys>
+      {children}
+    </CommandListContext.Provider>
+  )
+}
+
+export default CommandListArea

--- a/src/components/CommandListArea/CommandListArea.tsx
+++ b/src/components/CommandListArea/CommandListArea.tsx
@@ -21,7 +21,7 @@ const CommandListArea: React.FC<Props> = ({ commandList, children }) => {
   return (
     <CommandListContext.Provider value={commandList}>
       <Hotkeys keyName="command+shift+p" onKeyDown={(_, evn: KeyboardEvent, $) => handleKeyDown(_, evn, $)}>
-        {isRunning ? <CommandList /> : <></>}
+        {isRunning ? <CommandList setIsRunning={setIsRunning} /> : <></>}
       </Hotkeys>
       {children}
     </CommandListContext.Provider>

--- a/src/components/CommandListArea/CommandListArea.tsx
+++ b/src/components/CommandListArea/CommandListArea.tsx
@@ -22,7 +22,7 @@ const CommandListArea: React.FC<Props> = ({ commandList, children, setComponent 
 
   const handleClose = () => {
     setIsRunning(false)
-    document.removeEventListener('click',handleClose)
+    document.removeEventListener('click', handleClose)
   }
 
   return (

--- a/src/components/CommandListArea/CommandListArea.tsx
+++ b/src/components/CommandListArea/CommandListArea.tsx
@@ -6,11 +6,12 @@ import { CommandList } from '@/components'
 type Props = {
   commandList: Command[]
   children: React.ReactNode[]
+  setComponent: React.Dispatch<React.SetStateAction<React.ReactNode>>
 }
 
 export const CommandListContext = createContext<Command[]>([])
 
-const CommandListArea: React.FC<Props> = ({ commandList, children }) => {
+const CommandListArea: React.FC<Props> = ({ commandList, children, setComponent }) => {
   const [isRunning, setIsRunning] = useState(false)
 
   const handleKeyDown: OnKeyFun = (_, e) => {
@@ -21,7 +22,7 @@ const CommandListArea: React.FC<Props> = ({ commandList, children }) => {
   return (
     <CommandListContext.Provider value={commandList}>
       <Hotkeys keyName="command+shift+p" onKeyDown={(_, evn: KeyboardEvent, $) => handleKeyDown(_, evn, $)}>
-        {isRunning ? <CommandList setIsRunning={setIsRunning} /> : <></>}
+        {isRunning ? <CommandList setIsRunning={setIsRunning} setComponent={setComponent} /> : <></>}
       </Hotkeys>
       {children}
     </CommandListContext.Provider>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -18,7 +18,7 @@ import { BiTask } from 'react-icons/bi'
 import { useHistory, withRouter } from 'react-router-dom'
 import { rgba } from 'polished'
 
-const pages = ['Components', 'Documents', 'Matrix', 'Instructions']
+const pages = ['Components', 'Documents', 'Instructions']
 const settings = ['Login', 'Account']
 
 const Header: React.FC = () => {

--- a/src/components/MatrixArea/MatrixArea.tsx
+++ b/src/components/MatrixArea/MatrixArea.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { MatrixRain } from '@/components'
+import styled from 'styled-components'
 
 type Props = {
   width?: number
@@ -11,27 +12,30 @@ const MatrixArea: React.FC<Props> = (props: Props) => {
   const streamCount = Math.floor(window.innerWidth / 26)
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'center',
-        position: 'fixed',
-        top: '10%',
-        left: 0,
-        bottom: 0,
-        right: 0,
-        overflow: 'ignore',
-        width: width,
-        height: height,
-      }}
+    <_MatrixWrapper
+      width={width}
+      height={height}
     >
-      ちょっと待つとここに文字が流れます！
       {new Array(streamCount).fill(undefined).map((_, index) => (
         <MatrixRain key={index} />
       ))}
-    </div>
+    </_MatrixWrapper>
   )
 }
+
+const _MatrixWrapper = styled.div<Props>`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  position: fixed;
+  top: 10%;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  overflow: ignore;
+  width: ${({width}) => width};
+  height: ${({height}) => height};;
+  z-index: 1000;
+`
 
 export default MatrixArea

--- a/src/components/MatrixArea/MatrixArea.tsx
+++ b/src/components/MatrixArea/MatrixArea.tsx
@@ -12,10 +12,7 @@ const MatrixArea: React.FC<Props> = (props: Props) => {
   const streamCount = Math.floor(window.innerWidth / 26)
 
   return (
-    <_MatrixWrapper
-      width={width}
-      height={height}
-    >
+    <_MatrixWrapper width={width} height={height}>
       {new Array(streamCount).fill(undefined).map((_, index) => (
         <MatrixRain key={index} />
       ))}
@@ -33,8 +30,8 @@ const _MatrixWrapper = styled.div<Props>`
   bottom: 0;
   right: 0;
   overflow: ignore;
-  width: ${({width}) => width};
-  height: ${({height}) => height};;
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
   z-index: 1000;
 `
 

--- a/src/components/MatrixArea/MatrixArea.tsx
+++ b/src/components/MatrixArea/MatrixArea.tsx
@@ -32,7 +32,7 @@ const _MatrixWrapper = styled.div<Props>`
   overflow: ignore;
   width: ${({ width }) => width};
   height: ${({ height }) => height};
-  z-index: 1000;
+  /* z-index: 1000; */
 `
 
 export default MatrixArea

--- a/src/components/MatrixRain/MatrixRain.tsx
+++ b/src/components/MatrixRain/MatrixRain.tsx
@@ -51,29 +51,24 @@ const MatrixRain: React.FC = () => {
 
   return (
     <>
-        <div
-          style={{
-            marginTop: marginTop,
-            color: '#00F8F8',
-            writingMode: 'vertical-rl',
-            textOrientation: 'upright',
-            userSelect: 'none',
-            whiteSpace: 'nowrap',
-            textShadow: '0px 0px 8px rgba(32, 194, 14, 0.8)',
-            fontSize: 15,
-          }}
-        >
-          {stream.map((char, index) => (
-            <_MatrixRainChars
-              key={index}
-              index={index}
-              stream={stream}
-              getRandomInt={() => getRandomInt(10, 30)}
-            >
-              {char}
-            </_MatrixRainChars>
-          ))}
-        </div>
+      <div
+        style={{
+          marginTop: marginTop,
+          color: '#00F8F8',
+          writingMode: 'vertical-rl',
+          textOrientation: 'upright',
+          userSelect: 'none',
+          whiteSpace: 'nowrap',
+          textShadow: '0px 0px 8px rgba(32, 194, 14, 0.8)',
+          fontSize: 15,
+        }}
+      >
+        {stream.map((char, index) => (
+          <_MatrixRainChars key={index} index={index} stream={stream} getRandomInt={() => getRandomInt(10, 30)}>
+            {char}
+          </_MatrixRainChars>
+        ))}
+      </div>
     </>
   )
 }
@@ -91,9 +86,10 @@ const MatrixRain: React.FC = () => {
 // `
 
 const _MatrixRainChars = styled.a<MatrixRainChars>`
-  color: ${({stream, index}) => (index === stream.length - 1) ? '#00F8F8' : undefined};
-  opacity: ${({getRandomInt, index}) => (index < getRandomInt(10, 30)) ? 0.1 + 0.15 : 1};
-  text-shadow: ${({stream, index}) => (index === stream.length - 1) ? '0px 0px 20px rgba(255, 255, 255, 1)' : undefined};
+  color: ${({ stream, index }) => (index === stream.length - 1 ? '#00F8F8' : undefined)};
+  opacity: ${({ getRandomInt, index }) => (index < getRandomInt(10, 30) ? 0.1 + 0.15 : 1)};
+  text-shadow: ${({ stream, index }) =>
+    index === stream.length - 1 ? '0px 0px 20px rgba(255, 255, 255, 1)' : undefined};
 `
 
 export default MatrixRain

--- a/src/components/MatrixRain/MatrixRain.tsx
+++ b/src/components/MatrixRain/MatrixRain.tsx
@@ -1,8 +1,17 @@
 import React, { useState } from 'react'
 import { getRandomInt } from '@/data/utils'
 import useInterval from '@use-it/interval'
-import { createTheme } from '@material-ui/core'
-import { ThemeProvider } from '@/components'
+import styled from 'styled-components'
+
+// type MatrixRainWrapper = {
+//   marginTop: number | string
+// }
+
+type MatrixRainChars = {
+  stream: string[]
+  index: number
+  getRandomInt: (min: number, max: number) => number
+}
 
 const validChar =
   'abcdefghijklmnopqrstuvwxyz0123456789$+-*/=モジレツリアクトジャバスクリプトサイバーパンクネオトウキョウサイバーブレードランナーコウカクキドウタイマトリックストロンアキラゴーストインザシェル'
@@ -28,15 +37,6 @@ const getMutatedStream = (stream: string[]) => {
   return newStream
 }
 
-const hachiMaruPopFont = createTheme({
-  typography: {
-    fontFamily: ['Hachi Maru Pop'].join(','),
-  },
-  palette: {
-    type: 'dark',
-  },
-})
-
 const MatrixRain: React.FC = () => {
   const [stream, setStream] = useState(getRandomStream())
   const [marginTop, setMarginTop] = useState(stream.length * -50)
@@ -51,8 +51,6 @@ const MatrixRain: React.FC = () => {
 
   return (
     <>
-      <link href="https://fonts.googleapis.com/css2?family=Hachi+Maru+Pop&display=swap" rel="stylesheet" />
-      <ThemeProvider theme={hachiMaruPopFont}>
         <div
           style={{
             marginTop: marginTop,
@@ -66,21 +64,36 @@ const MatrixRain: React.FC = () => {
           }}
         >
           {stream.map((char, index) => (
-            <a
+            <_MatrixRainChars
               key={index}
-              style={{
-                color: index === stream.length - 1 ? '#00F8F8' : undefined,
-                opacity: index < getRandomInt(10, 30) ? 0.1 + 0.15 : 1,
-                textShadow: index === stream.length - 1 ? '0px 0px 20px rgba(255, 255, 255, 1)' : undefined,
-              }}
+              index={index}
+              stream={stream}
+              getRandomInt={() => getRandomInt(10, 30)}
             >
               {char}
-            </a>
+            </_MatrixRainChars>
           ))}
         </div>
-      </ThemeProvider>
     </>
   )
 }
+
+// const _MatrixRainWrapper = styled.div<MatrixRainWrapper>`
+//   margin-top: ${({marginTop}) => marginTop};
+//   color: #00F8F8;
+//   writing-mode: vertical-rl;
+//   text-orientation: upright;
+//   user-select: none;
+//   white-space: nowrap;
+//   text-shadow: 0px 0px 8px rgba(32, 194, 14, 0.8);
+//   font-size: 15;
+//   font-family: 'HachiMaruPopFont';
+// `
+
+const _MatrixRainChars = styled.a<MatrixRainChars>`
+  color: ${({stream, index}) => (index === stream.length - 1) ? '#00F8F8' : undefined};
+  opacity: ${({getRandomInt, index}) => (index < getRandomInt(10, 30)) ? 0.1 + 0.15 : 1};
+  text-shadow: ${({stream, index}) => (index === stream.length - 1) ? '0px 0px 20px rgba(255, 255, 255, 1)' : undefined};
+`
 
 export default MatrixRain

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -34,6 +34,9 @@ export { default as MatrixArea } from './MatrixArea/MatrixArea'
 export { default as InstructionsArea } from './InstructionsArea/InstructionsArea'
 export { default as ProgressBar } from './ProgressBar/ProgressBar'
 export { default as ProgressArea } from './ProgressArea/ProgressArea'
+export { default as Alert } from './Alert/Alert'
+export { default as CommandList } from './CommandList/CommandList'
+export { default as CommandListProvider } from './CommandListArea/CommandListArea'
 
 export const getHeaders = async (token: string): Promise<{ authorization?: string }> => {
   const authorization = `bearer ${token}`

--- a/src/data/commandList.tsx
+++ b/src/data/commandList.tsx
@@ -5,13 +5,13 @@ export const commandList: Command[] = [
   {
     name: 'alert',
     component: <Alert />,
-    title: 'アラートコマンド',
-    desc: 'アラートを発火させるコマンド',
+    title: 'Alert',
+    desc: 'Command to fire an alert',
   },
   {
     name: 'matrix',
     component: <MatrixArea />,
-    title: 'マトリックスコマンド',
-    desc: 'マトリックスレインを降らせるコマンド',
+    title: 'MatrixRain',
+    desc: 'Command to drop Matrix Rain',
   },
 ]

--- a/src/data/commandList.tsx
+++ b/src/data/commandList.tsx
@@ -1,0 +1,11 @@
+import { Alert } from '@/components'
+import { Command } from '@/types'
+
+export const commandList: Command[] = [
+  {
+    name: 'alert',
+    component: <Alert />,
+    title: 'アラートコマンド',
+    desc: 'アラートを発火させるコマンド',
+  },
+]

--- a/src/data/commandList.tsx
+++ b/src/data/commandList.tsx
@@ -1,4 +1,4 @@
-import { Alert } from '@/components'
+import { Alert, MatrixArea } from '@/components'
 import { Command } from '@/types'
 
 export const commandList: Command[] = [
@@ -7,5 +7,11 @@ export const commandList: Command[] = [
     component: <Alert />,
     title: 'アラートコマンド',
     desc: 'アラートを発火させるコマンド',
+  },
+  {
+    name: 'matrix',
+    component: <MatrixArea />,
+    title: 'マトリックスコマンド',
+    desc: 'マトリックスレインを降らせるコマンド',
   },
 ]

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,12 @@
     url("./fonts/tron.ttf") format("truetype");
 }
 
+@font-face {
+  font-family: "HachiMaruPopFont";
+  src: local("HachiMaruPop"),
+    url("./fonts/HachiMaruPop-Regular.ttf") format("truetype");
+}
+
 /*スクロールバー全体*/
 ::-webkit-scrollbar {
   width: 15px;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 export interface Label {
   color?: string
   description?: string
@@ -43,3 +45,10 @@ export type SkillTableContents = {
   steps: string[]
   activeStep: number
 }[]
+
+export type Command = {
+  name: string
+  component: ReactNode
+  title: string
+  desc: string
+}


### PR DESCRIPTION
## 作業概要

#133 

- 「command + Shift + p」でコマンドリストを表示する
- マトリックス画面をコマンド実行で表示するように修正し、ヘッダーから削除
- コマンドは alert, matrixを用意した
- 入力されたテキストとコマンドを前方一致させて表示する仕様

## 動作確認

![xxx](https://user-images.githubusercontent.com/76277215/173228277-2f323b32-e22f-488b-869a-d9bd32977443.gif)

