### PR TITLE
Circularの内部コンテンツが少なくなった時にレイアウトが崩れてしまう問題への対応

### DIFF
--- a/src/data/dummy.tsx
+++ b/src/data/dummy.tsx
@@ -1,4 +1,4 @@
-import { Issue } from "@/types";
+import { Issue } from '@/types'
 
 export const dummyIssue: Issue = {
   id: '',
@@ -13,5 +13,5 @@ export const dummyIssue: Issue = {
     login: 'Yuisei-Maruyama',
     avatar_url: 'https://avatars.githubusercontent.com/u/76277215?v=4',
   },
-  labels: []
+  labels: [],
 }

--- a/src/data/dummy.tsx
+++ b/src/data/dummy.tsx
@@ -1,0 +1,17 @@
+import { Issue } from "@/types";
+
+export const dummyIssue: Issue = {
+  id: '',
+  title: 'ダミースライド',
+  body: 'Circularのレイアウト崩れを防ぐ意図で暫定的に表示しています。',
+  number: 1,
+  state: 'open',
+  /* eslint-disable camelcase */
+  html_url: 'https://github.com/Yuisei-Maruyama/MyPortfolio/issues/',
+  user: {
+    url: 'https://api.github.com/users/Yuisei-Maruyama',
+    login: 'Yuisei-Maruyama',
+    avatar_url: 'https://avatars.githubusercontent.com/u/76277215?v=4',
+  },
+  labels: []
+}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -15,6 +15,7 @@ import { Issues } from '@/types'
 import axios from 'axios'
 import { skillTableData } from '@/data/skillTableData'
 import { message } from '@/data/message'
+import { dummyIssue } from '@/data/dummy'
 
 const request = axios.create({
   baseURL: 'https://api.github.com',
@@ -59,6 +60,10 @@ const Main = () => {
     fetchRepoLanguageList()
     // eslint-disable-next-line
   }, [])
+
+  if (todoItems.length < 7) {
+    todoItems.push(dummyIssue)
+  }
 
   return (
     <div>


### PR DESCRIPTION
## 作業概要

#148 

- 暫定的に `todoItems` が **7以下** になると、レイアウトが崩れてしまうので、ダミーのスライドを差し込むようにした

## 動作確認

![xxx](https://user-images.githubusercontent.com/76277215/173234950-8d0d3896-6210-4987-8871-454c2b27d19a.gif)

